### PR TITLE
Added Laravel 5.4 Support

### DIFF
--- a/src/DkimMailServiceProvider.php
+++ b/src/DkimMailServiceProvider.php
@@ -22,6 +22,8 @@ class DkimMailServiceProvider extends MailServiceProvider
             $mailer = new Mailer(
                 $app['view'], $app['swift.mailer'], $app['events']
             );
+
+            $mailer->setQueue(app('queue'));
             
             if (method_exists($this, 'setMailerDependencies')) {
                 $this->setMailerDependencies($mailer, $app);


### PR DESCRIPTION
Implemented queue to Mailer initializing. 

Resolves: `Type error: Argument 1 passed to Illuminate\Mail\Mailer::setQueue() must implement interface Illuminate\Contracts\Queue\Factory, instance of Illuminate\Queue\SyncQueue given`

Bug Details:  https://github.com/laravel/lumen-framework/issues/590#issuecomment-338594805