### PR TITLE
Adding passphrase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Vitalybaev\LaravelDkim\DkimMailServiceProvider::class,
 'dkim_private_key' => env('MAIL_DKIM_PRIVATE_KEY'), // path to private key, required
 'dkim_identity' => env('MAIL_DKIM_IDENTITY'), // identity (optional)
 'dkim_algo' => env('MAIL_DKIM_ALGO'), // sign algorithm (defaults to rsa-sha256)
+'dkim_passphrase' => env('MAIL_DKIM_PASSPHRASE'), // private key passphrase (optional)
 ```
 
 > **NOTE!** This package signs all emails only when mail driver is `smtp` and all required settings exist.

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -20,7 +20,7 @@ class Mailer extends \Illuminate\Mail\Mailer
         if (in_array(strtolower(config('mail.driver')), ['smtp', 'sendmail', 'log'])) {
             if (config('mail.dkim_private_key') && file_exists(config('mail.dkim_private_key'))) {
                 if (config('mail.dkim_selector') && config('mail.dkim_domain')) {
-                    $message->attachDkim(config('mail.dkim_selector'), config('mail.dkim_domain'), file_get_contents(config('mail.dkim_private_key')));
+                    $message->attachDkim(config('mail.dkim_selector'), config('mail.dkim_domain'), file_get_contents(config('mail.dkim_private_key')), config('mail.dkim_passphrase'));
                 }
             }
         }

--- a/src/Message.php
+++ b/src/Message.php
@@ -10,12 +10,13 @@ class Message extends \Illuminate\Mail\Message
      * @param $selector
      * @param $domain
      * @param $privateKey
+     * @param $passphrase
      *
      * @return $this
      */
-    public function attachDkim($selector, $domain, $privateKey)
+    public function attachDkim($selector, $domain, $privateKey, $passphrase = '')
     {
-        $signer = new Swift_Signers_DKIMSigner($privateKey, $domain, $selector);
+        $signer = new Swift_Signers_DKIMSigner($privateKey, $domain, $selector, $passphrase);
         $signer->setHashAlgorithm(config('mail.dkim_algo', 'rsa-sha256'));
         if (config('mail.dkim_identity')) {
             $signer->setSignerIdentity(config('mail.dkim_identity'));


### PR DESCRIPTION
The passphase parameter was missing. Added it to Mailer.php and Message.php. 
Also updated the README with the new config.