### PR TITLE
Make compatible DKIM signer with driver mail

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -17,7 +17,7 @@ class Mailer extends \Illuminate\Mail\Mailer
             $message->from($this->from['address'], $this->from['name']);
         }
 
-        if (in_array(strtolower(config('mail.driver')), ['smtp', 'sendmail', 'log'])) {
+        if (in_array(strtolower(config('mail.driver')), ['smtp', 'sendmail', 'log', 'mail'])) {
             if (config('mail.dkim_private_key') && file_exists(config('mail.dkim_private_key'))) {
                 if (config('mail.dkim_selector') && config('mail.dkim_domain')) {
                     $message->attachDkim(config('mail.dkim_selector'), config('mail.dkim_domain'), file_get_contents(config('mail.dkim_private_key')), config('mail.dkim_passphrase'));


### PR DESCRIPTION
Hello.

Why not make compatible with the mail driver?
I often leave the driver to mail for my Laravel projects.
So I allowed myself to add it in the condition.

Thank you.