### PR TITLE
Override registerIlluminateMailer() instead of register()

### DIFF
--- a/src/DkimMailServiceProvider.php
+++ b/src/DkimMailServiceProvider.php
@@ -11,10 +11,8 @@ class DkimMailServiceProvider extends MailServiceProvider
      *
      * @return void
      */
-    public function register()
+    public function registerIlluminateMailer()
     {
-        parent::registerSwiftMailer();
-
         $this->app->singleton('mailer', function ($app) {
             // Once we have create the mailer instance, we will set a container instance
             // on the mailer. This allows us to resolve mailer classes via containers


### PR DESCRIPTION
Adding laravel5-dkim broke my custom templates. This commit fixes that.

class  `Illuminate\Mail\MailServiceProvider` implements register() as three calls to the methods:
```php
        $this->registerSwiftMailer();
        $this->registerIlluminateMailer();
        $this->registerMarkdownRenderer();
```
Previously the call to `registerMarkdownRenderer()` was missing from `DkimMailServiceProvider`.

I could have added this, but instead I opted to override registerIlluminateMailer() instead, which I find a cleaner solution.